### PR TITLE
Rewrite benchmarks for more accurate results

### DIFF
--- a/benchmarks/ecstasy.cpp
+++ b/benchmarks/ecstasy.cpp
@@ -1,6 +1,7 @@
 #include "benchpress.hpp"
 #include <ecstasy/core/Engine.h>
 #include <ecstasy/systems/IteratingSystem.h>
+#include <random>
 
 namespace ecstasy_benchmarks {
 	const int NUM_ENTITIES = 1 << 15;
@@ -87,13 +88,22 @@ namespace ecstasy_benchmarks {
 			engine.addSystem<IteratingSystemD>();
 			engine.addSystem<IteratingSystemE>();
 
+			std::vector<int> v;
+
+			for (int i = 0; i < NUM_ENTITIES; i++) {
+				v.push_back(i);
+			}
+
+			std::mt19937 g(0);
+			std::shuffle(v.begin(), v.end(), g);
+
 			for (int i = 0; i < NUM_ENTITIES; i++) {
 				Entity *entity = engine.createEntity();
-				if (i & 1)  entity->assign<ComponentA>();
-				if (i & 2)  entity->assign<ComponentB>();
-				if (i & 4)  entity->assign<ComponentC>();
-				if (i & 8)  entity->assign<ComponentD>();
-				if (i & 16) entity->assign<ComponentE>();
+				if (v[i] & 1)  entity->assign<ComponentA>();
+				if (v[i] & 2)  entity->assign<ComponentB>();
+				if (v[i] & 4)  entity->assign<ComponentC>();
+				if (v[i] & 8)  entity->assign<ComponentD>();
+				if (v[i] & 16) entity->assign<ComponentE>();
 				engine.addEntity(entity);
 			}
 		}

--- a/benchmarks/ecstasy.cpp
+++ b/benchmarks/ecstasy.cpp
@@ -1,77 +1,109 @@
 #include "benchpress.hpp"
-#include<ecstasy/core/Engine.h>
-#include<ecstasy/systems/IteratingSystem.h>
-#include <random>
+#include <ecstasy/core/Engine.h>
+#include <ecstasy/systems/IteratingSystem.h>
 
 namespace ecstasy_benchmarks {
-	const int COMPONENT_VALUES = 8;
-	const int NUM_ENTITIES = 2 << 14;
-	
-	struct ComponentMock1 : public Component<ComponentMock1> { int values[COMPONENT_VALUES]; };
-	struct ComponentMock2 : public Component<ComponentMock2> { float values[COMPONENT_VALUES]; };
-	struct ComponentMock3 : public Component<ComponentMock3> { int values[COMPONENT_VALUES]; };
-	struct ComponentMock4 : public Component<ComponentMock4> { float values[COMPONENT_VALUES]; };
-	struct ComponentMock5 : public Component<ComponentMock5> { int values[COMPONENT_VALUES]; };
-	struct ComponentMock6 : public Component<ComponentMock6> { float values[COMPONENT_VALUES]; };
-	struct ComponentMock7 : public Component<ComponentMock7> { int values[COMPONENT_VALUES]; };
-	struct ComponentMock8 : public Component<ComponentMock8> { float values[COMPONENT_VALUES]; };
-	
-	template<typename T, int I>
-	class EntitySystemMock : public IteratingSystem<EntitySystemMock<T, I>> {
+	const int NUM_ENTITIES = 1 << 16;
+
+	struct ComponentA : public Component<ComponentA> { float a; float b; float c; };
+	struct ComponentB : public Component<ComponentB> { float a; float b; float c; };
+	struct ComponentC : public Component<ComponentC> { float a; float b; float c; };
+	struct ComponentD : public Component<ComponentD> { float a; float b; float c; };
+	struct ComponentE : public Component<ComponentE> { float a; float b; float c; };
+
+	struct IteratingSystemA : public IteratingSystem<IteratingSystemA> {
 	public:
-		float inc = I / 100.0f;
-		EntitySystemMock() : IteratingSystem<EntitySystemMock<T, I>>(Family::all<T>().get()) {}
-		
+		IteratingSystemA(): IteratingSystem<IteratingSystemA>(Family::all<ComponentA>().get()) {
+		}
+
 		void processEntity(Entity *entity, float deltaTime) override {
-			auto *c = entity->get<T>();
-			for(int i=0; i<COMPONENT_VALUES; i++) {
-				c->values[i] += inc;
-			}
+			ComponentA *c = entity->get<ComponentA>();
+			c->a++;
+			c->b++;
+			c->c++;
 		}
 	};
-	
+
+	struct IteratingSystemB : public IteratingSystem<IteratingSystemB> {
+	public:
+		IteratingSystemB(): IteratingSystem<IteratingSystemB>(Family::all<ComponentB>().get()) {
+		}
+
+		void processEntity(Entity *entity, float deltaTime) override {
+			ComponentB *c = entity->get<ComponentB>();
+			c->a++;
+			c->b++;
+			c->c++;
+		}
+	};
+
+	struct IteratingSystemC : public IteratingSystem<IteratingSystemC> {
+	public:
+		IteratingSystemC(): IteratingSystem<IteratingSystemC>(Family::all<ComponentC>().get()) {
+		}
+
+		void processEntity(Entity *entity, float deltaTime) override {
+			ComponentC *c = entity->get<ComponentC>();
+			c->a++;
+			c->b++;
+			c->c++;
+		}
+	};
+
+	struct IteratingSystemD : public IteratingSystem<IteratingSystemD> {
+	public:
+		IteratingSystemD(): IteratingSystem<IteratingSystemD>(Family::all<ComponentD>().get()) {
+		}
+
+		void processEntity(Entity *entity, float deltaTime) override {
+			ComponentD *c = entity->get<ComponentD>();
+			c->a++;
+			c->b++;
+			c->c++;
+		}
+	};
+
+	struct IteratingSystemE : public IteratingSystem<IteratingSystemE> {
+	public:
+		IteratingSystemE(): IteratingSystem<IteratingSystemE>(Family::all<ComponentE>().get()) {
+		}
+
+		void processEntity(Entity *entity, float deltaTime) override {
+			ComponentE *c = entity->get<ComponentE>();
+			c->a++;
+			c->b++;
+			c->c++;
+		}
+	};
+
 	class Benchmark  {
 	public:
 		Engine engine;
+
 		Benchmark() {
-			engine.addSystem<EntitySystemMock<ComponentMock1, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock1, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock2, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock2, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock3, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock3, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock4, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock4, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock5, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock5, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock6, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock6, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock7, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock7, -123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock8, 123>>();
-			engine.addSystem<EntitySystemMock<ComponentMock8, -123>>();
-			
-			std::default_random_engine generator;
-			std::uniform_int_distribution<int> distribution(0,8);
-			for(int i=0; i<NUM_ENTITIES; i++) {
-				auto *e = engine.createEntity();
-				if(distribution(generator) == 1) e->assign<ComponentMock1>();
-				if(distribution(generator) == 2) e->assign<ComponentMock2>();
-				if(distribution(generator) == 3) e->assign<ComponentMock3>();
-				if(distribution(generator) == 4) e->assign<ComponentMock4>();
-				if(distribution(generator) == 5) e->assign<ComponentMock5>();
-				if(distribution(generator) == 6) e->assign<ComponentMock6>();
-				if(distribution(generator) == 7) e->assign<ComponentMock7>();
-				if(distribution(generator) == 8) e->assign<ComponentMock8>();
-				engine.addEntity(e);
+			engine.addSystem<IteratingSystemA>();
+			engine.addSystem<IteratingSystemB>();
+			engine.addSystem<IteratingSystemC>();
+			engine.addSystem<IteratingSystemD>();
+			engine.addSystem<IteratingSystemE>();
+
+			for (int i = 0; i < NUM_ENTITIES; i++) {
+				Entity *entity = engine.createEntity();
+				if (i & 1)  entity->assign<ComponentA>();
+				if (i & 2)  entity->assign<ComponentB>();
+				if (i & 4)  entity->assign<ComponentC>();
+				if (i & 8)  entity->assign<ComponentD>();
+				if (i & 16) entity->assign<ComponentE>();
+				engine.addEntity(entity);
 			}
 		}
+
 		void run(benchpress::context *ctx) {
 			for (size_t i = 0; i < ctx->num_iterations(); ++i) {
-				engine.update(0);
+				engine.update(42.0);
 			}
 		}
 	};
-	BENCHMARK(Benchmark, "ECStasy");
+	BENCHMARK(Benchmark, "ECS-Tasy");
 
 }

--- a/benchmarks/ecstasy.cpp
+++ b/benchmarks/ecstasy.cpp
@@ -3,7 +3,7 @@
 #include <ecstasy/systems/IteratingSystem.h>
 
 namespace ecstasy_benchmarks {
-	const int NUM_ENTITIES = 1 << 16;
+	const int NUM_ENTITIES = 1 << 15;
 
 	struct ComponentA : public Component<ComponentA> { float a; float b; float c; };
 	struct ComponentB : public Component<ComponentB> { float a; float b; float c; };

--- a/benchmarks/entityx.cpp
+++ b/benchmarks/entityx.cpp
@@ -87,11 +87,7 @@ namespace entityx_benchmarks {
 		}
 
 		void update(TimeDelta dt) {
-			systems.update<IteratingSystemA>(dt);
-			systems.update<IteratingSystemB>(dt);
-			systems.update<IteratingSystemC>(dt);
-			systems.update<IteratingSystemD>(dt);
-			systems.update<IteratingSystemE>(dt);
+			systems.update_all(dt);
 		}
 	};
 

--- a/benchmarks/entityx.cpp
+++ b/benchmarks/entityx.cpp
@@ -1,8 +1,10 @@
 #include "benchpress.hpp"
 #include "entityx/entityx.h"
+#include <random>
 
 namespace entityx_benchmarks {
 	const int NUM_ENTITIES = 1 << 15;
+
 	using namespace entityx;
 
 	struct ComponentA { float a; float b; float c; };
@@ -76,13 +78,22 @@ namespace entityx_benchmarks {
 			systems.add<IteratingSystemE>();
 			systems.configure();
 
+			std::vector<int> v;
+
+			for (int i = 0; i < NUM_ENTITIES; i++) {
+				v.push_back(i);
+			}
+
+			std::mt19937 g(0);
+			std::shuffle(v.begin(), v.end(), g);
+
 			for (int i = 0; i < NUM_ENTITIES; i++) {
 				Entity entity = entities.create();
-				if (i & 1)  entity.assign<ComponentA>();
-				if (i & 2)  entity.assign<ComponentB>();
-				if (i & 4)  entity.assign<ComponentC>();
-				if (i & 8)  entity.assign<ComponentD>();
-				if (i & 16) entity.assign<ComponentE>();
+				if (v[i] & 1)  entity.assign<ComponentA>();
+				if (v[i] & 2)  entity.assign<ComponentB>();
+				if (v[i] & 4)  entity.assign<ComponentC>();
+				if (v[i] & 8)  entity.assign<ComponentD>();
+				if (v[i] & 16) entity.assign<ComponentE>();
 			}
 		}
 

--- a/benchmarks/entityx.cpp
+++ b/benchmarks/entityx.cpp
@@ -2,8 +2,7 @@
 #include "entityx/entityx.h"
 
 namespace entityx_benchmarks {
-	const int NUM_ENTITIES = 1 << 16;
-	
+	const int NUM_ENTITIES = 1 << 15;
 	using namespace entityx;
 
 	struct ComponentA { float a; float b; float c; };

--- a/benchmarks/entityx.cpp
+++ b/benchmarks/entityx.cpp
@@ -1,81 +1,114 @@
 #include "benchpress.hpp"
-#include "entityx/Entity.h"
-#include "entityx/System.h"
-#include <random>
+#include "entityx/entityx.h"
 
 namespace entityx_benchmarks {
-	const int COMPONENT_VALUES = 8;
-	const int NUM_ENTITIES = 2 << 14;
+	const int NUM_ENTITIES = 1 << 16;
 	
 	using namespace entityx;
-	struct ComponentMock1 { int values[COMPONENT_VALUES]; };
-	struct ComponentMock2 { float values[COMPONENT_VALUES]; };
-	struct ComponentMock3 { int values[COMPONENT_VALUES]; };
-	struct ComponentMock4 { float values[COMPONENT_VALUES]; };
-	struct ComponentMock5 { int values[COMPONENT_VALUES]; };
-	struct ComponentMock6 { float values[COMPONENT_VALUES]; };
-	struct ComponentMock7 { int values[COMPONENT_VALUES]; };
-	struct ComponentMock8 { float values[COMPONENT_VALUES]; };
-	
-	template<typename T, int I>
-	class EntitySystemMock : public System<EntitySystemMock<T, I>> {
-	public:
-		float inc = I / 100.0f;
-		void update(entityx::EntityManager &entityManager, entityx::EventManager &eventManager, entityx::TimeDelta dt) override {
-			ComponentHandle<T> c;
-			for (auto entity : entityManager.entities_with_components<T>(c))
-			{
-				for(int i=0; i<COMPONENT_VALUES; i++) {
-					c->values[i] += inc;
-				}
+
+	struct ComponentA { float a; float b; float c; };
+	struct ComponentB { float a; float b; float c; };
+	struct ComponentC { float a; float b; float c; };
+	struct ComponentD { float a; float b; float c; };
+	struct ComponentE { float a; float b; float c; };
+
+	struct IteratingSystemA : public System<IteratingSystemA> {
+		void update(entityx::EntityManager &es, entityx::EventManager &events, TimeDelta dt) override {
+			ComponentHandle<ComponentA> component;
+			for (Entity entity : es.entities_with_components(component)) {
+				component->a++;
+				component->b++;
+				component->c++;
 			}
+		};
+	};
+
+	struct IteratingSystemB : public System<IteratingSystemB> {
+		void update(entityx::EntityManager &es, entityx::EventManager &events, TimeDelta dt) override {
+			ComponentHandle<ComponentB> component;
+			for (Entity entity : es.entities_with_components(component)) {
+				component->a++;
+				component->b++;
+				component->c++;
+			}
+		};
+	};
+
+	struct IteratingSystemC : public System<IteratingSystemC> {
+		void update(entityx::EntityManager &es, entityx::EventManager &events, TimeDelta dt) override {
+			ComponentHandle<ComponentC> component;
+			for (Entity entity : es.entities_with_components(component)) {
+				component->a++;
+				component->b++;
+				component->c++;
+			}
+		};
+	};
+
+	struct IteratingSystemD : public System<IteratingSystemD> {
+		void update(entityx::EntityManager &es, entityx::EventManager &events, TimeDelta dt) override {
+			ComponentHandle<ComponentD> component;
+			for (Entity entity : es.entities_with_components(component)) {
+				component->a++;
+				component->b++;
+				component->c++;
+			}
+		};
+	};
+
+	struct IteratingSystemE : public System<IteratingSystemE> {
+		void update(entityx::EntityManager &es, entityx::EventManager &events, TimeDelta dt) override {
+			ComponentHandle<ComponentE> component;
+			for (Entity entity : es.entities_with_components(component)) {
+				component->a++;
+				component->b++;
+				component->c++;
+			}
+		};
+	};
+
+	class IteratingManager : public EntityX {
+	public:
+		explicit IteratingManager() {
+			systems.add<IteratingSystemA>();
+			systems.add<IteratingSystemB>();
+			systems.add<IteratingSystemC>();
+			systems.add<IteratingSystemD>();
+			systems.add<IteratingSystemE>();
+			systems.configure();
+
+			for (int i = 0; i < NUM_ENTITIES; i++) {
+				Entity entity = entities.create();
+				if (i & 1)  entity.assign<ComponentA>();
+				if (i & 2)  entity.assign<ComponentB>();
+				if (i & 4)  entity.assign<ComponentC>();
+				if (i & 8)  entity.assign<ComponentD>();
+				if (i & 16) entity.assign<ComponentE>();
+			}
+		}
+
+		void update(TimeDelta dt) {
+			systems.update<IteratingSystemA>(dt);
+			systems.update<IteratingSystemB>(dt);
+			systems.update<IteratingSystemC>(dt);
+			systems.update<IteratingSystemD>(dt);
+			systems.update<IteratingSystemE>(dt);
 		}
 	};
-	
-	class Benchmark  {
+
+	class Benchmark {
 	public:
-		EventManager m_events;
-		EntityManager m_entities;
-		SystemManager m_systems;
-		Benchmark() :  m_entities(m_events), m_systems(m_entities, m_events) {
-			m_systems.add<EntitySystemMock<ComponentMock1, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock1, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock2, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock2, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock3, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock3, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock4, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock4, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock5, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock5, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock6, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock6, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock7, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock7, -123>>();
-			m_systems.add<EntitySystemMock<ComponentMock8, 123>>();
-			m_systems.add<EntitySystemMock<ComponentMock8, -123>>();
-			m_systems.configure();
-			
-			std::default_random_engine generator;
-			std::uniform_int_distribution<int> distribution(0,8);
-			for(int i=0; i<NUM_ENTITIES; i++) {
-				auto e = m_entities.create();
-				if(distribution(generator) == 1) e.assign<ComponentMock1>();
-				if(distribution(generator) == 2) e.assign<ComponentMock2>();
-				if(distribution(generator) == 3) e.assign<ComponentMock3>();
-				if(distribution(generator) == 4) e.assign<ComponentMock4>();
-				if(distribution(generator) == 5) e.assign<ComponentMock5>();
-				if(distribution(generator) == 6) e.assign<ComponentMock6>();
-				if(distribution(generator) == 7) e.assign<ComponentMock7>();
-				if(distribution(generator) == 8) e.assign<ComponentMock8>();
-			}
+		IteratingManager iteratingManager;
+
+		Benchmark() {
 		}
+
 		void run(benchpress::context *ctx) {
 			for (size_t i = 0; i < ctx->num_iterations(); ++i) {
-				m_systems.update_all(0);
+				iteratingManager.update(42.0);
 			}
 		}
 	};
-	BENCHMARK(Benchmark, "entityx");
 
+	BENCHMARK(Benchmark, "entityx");
 }


### PR DESCRIPTION
Rewrite of the benchmarks for more accurate results; the previous benchmarks were probably flawed, but I don't know much of C++. Anyway, here's the results of the new benchmarks on my machine, running a release build:

```
ECS-Tasy                                    100    11235927 ns/op
entityx                                     500     2915293 ns/op
```

Commands used to run the benchmarks, for reference:

```
git clone git@github.com:antag99/ECS-tasy.git tasy
cd tasy/
git checkout feature/benchmarks
cd build/
./premake5 gmake
cd gmake/
make config=release
cd ../../binaries/
./benchmarks 
```

**EDIT:** Fixed mistake in command list
